### PR TITLE
Remove prevDeps from useFancyEffect #25

### DIFF
--- a/src/use-fancy-effect/useFancyEffect.test.tsx
+++ b/src/use-fancy-effect/useFancyEffect.test.tsx
@@ -221,6 +221,7 @@ describe('useFancyEffect', () => {
     render(<Component />);
 
     // first render
+    // mocked result -> true
     expect(callbackMock).toBeCalledTimes(1);
     expect(callbackMock).lastCalledWith(colors[0], 0);
     expect(fancyHelperMock).toBeCalledTimes(1);
@@ -239,6 +240,7 @@ describe('useFancyEffect', () => {
       prevDeps: undefined, newDeps: [colors[0]], count: 1,
     });
 
+    // mocked result -> true
     fireEvent.click(colorBtn);
     expect(callbackMock).toBeCalledTimes(2);
     expect(callbackMock).lastCalledWith(colors[1], 1);
@@ -247,6 +249,7 @@ describe('useFancyEffect', () => {
       prevDeps: [colors[0]], newDeps: [colors[1]], count: 2,
     });
 
+    // mocked result -> true
     fireEvent.click(colorBtn);
     expect(callbackMock).toBeCalledTimes(3);
     expect(callbackMock).lastCalledWith(colors[2], 1);
@@ -263,6 +266,7 @@ describe('useFancyEffect', () => {
       prevDeps: [colors[1]], newDeps: [colors[2]], count: 3,
     });
 
+    // mocked result -> true
     fireEvent.click(colorBtn);
     expect(callbackMock).toBeCalledTimes(4);
     expect(callbackMock).lastCalledWith(colors[3], 2);

--- a/src/use-fancy-effect/useFancyEffect.tsx
+++ b/src/use-fancy-effect/useFancyEffect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import cloneDeep from 'lodash/cloneDeep';
 
+import { deepClone } from '../utils';
 import { FancyEffectHelper } from '../../types';
 
 export function useFancyEffect(
@@ -10,16 +10,16 @@ export function useFancyEffect(
 ) {
   const depListRef = React.useRef<React.DependencyList>();
   const countRef = React.useRef(0);
-  const prevDeps = cloneDeep(depListRef.current);
 
   React.useEffect(() => {
-    depListRef.current = cloneDeep(dependencyList);
     countRef.current += 1;
 
     const passedFancyCondition = typeof fancyHelper === 'function' ? fancyHelper({
-      prevDeps, newDeps: dependencyList, count: countRef.current,
+      prevDeps: depListRef.current, newDeps: dependencyList, count: countRef.current,
     }) : true;
     const hasEmptyDependencies = Array.isArray(dependencyList) && dependencyList.length === 0;
+
+    depListRef.current = deepClone(dependencyList);
 
     if (hasEmptyDependencies || passedFancyCondition) {
       const callbackResult = callback();
@@ -27,6 +27,7 @@ export function useFancyEffect(
         return callbackResult;
       }
     }
+    // eslint hack!
     return undefined;
   }, dependencyList);
 }


### PR DESCRIPTION
By assigning value to `depListRef.current` after executing `fancyHelper` we do not need `prevDeps` any more.
resolved #25 